### PR TITLE
support the AMQ_RESET_CONFIG (like the downstream project)

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -6,10 +6,8 @@ COMMIT=$2
 DOCKER_REGISTRY=quay.io
 REPO=${DOCKER_REGISTRY}/enmasse/artemis-base
 
-echo "KWDEBUG VERSION .${VERSION}."
 if [ -n "${TRAVIS_TAG}" ]
 then
-    echo "KWDEBUG TRAVIS_TAG .${TRAVIS_TAG}."
     VERSION="${TRAVIS_TAG}"
 fi
 

--- a/utils/bin/launch.sh
+++ b/utils/bin/launch.sh
@@ -25,16 +25,16 @@ function configure() {
     local instanceDir=$1
     export CONTAINER_ID=$HOSTNAME
 
-    if [ ! -d ${instanceDir} -o "$AMQ_RESET_CONFIG" = "true" ]; then
+    if [ ! -d "${instanceDir}" -o "${AMQ_RESET_CONFIG}" = "true" ]; then
         echo "Creating instance in directory $instanceDir"
-        AMQ_ARGS=("create" "$instanceDir"
+        AMQ_ARGS=("create" "${instanceDir}"
                   "--user" "admin"
                   "--password" "admin"
                   "--role" "admin"
                   "--allow-anonymous"
-                  "--java-options" "$JAVA_OPTS")
+                  "--java-options" "${JAVA_OPTS}")
 
-        if [ "$AMQ_RESET_CONFIG" = "true" ]; then
+        if [ "${AMQ_RESET_CONFIG}" = "true" ]; then
             AMQ_ARGS+=("--force")
         fi
 

--- a/utils/bin/launch.sh
+++ b/utils/bin/launch.sh
@@ -25,9 +25,20 @@ function configure() {
     local instanceDir=$1
     export CONTAINER_ID=$HOSTNAME
 
-    if [ ! -d "${instanceDir}" ]; then
+    if [ ! -d ${instanceDir} -o "$AMQ_RESET_CONFIG" = "true" ]; then
         echo "Creating instance in directory $instanceDir"
-        $ARTEMIS_HOME/bin/artemis create $instanceDir --user admin --password admin --role admin --allow-anonymous --java-options "$JAVA_OPTS"
+        AMQ_ARGS=("create" "$instanceDir"
+                  "--user" "admin"
+                  "--password" "admin"
+                  "--role" "admin"
+                  "--allow-anonymous"
+                  "--java-options" "$JAVA_OPTS")
+
+        if [ "$AMQ_RESET_CONFIG" = "true" ]; then
+            AMQ_ARGS+=("--force")
+        fi
+
+        $ARTEMIS_HOME/bin/artemis ${AMQ_ARGS[@]}
     else
         echo "Reusing existing instance in directory $instanceDir"
     fi


### PR DESCRIPTION
If set true AMQ_RESET_CONFIG, the existing configuration and scripts of an existing Artemis instance is recreated.  The any existing journal is unaffected.  